### PR TITLE
Enable OpenSSF Scorecard GitHub Action

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,44 @@
+name: Scorecards supply-chain security
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '16 10 * * 6'
+  push:
+    branches: [ "main" ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v3
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@v1.0.26
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Scorecards.yml file enables the Scorecard action to run on push to main and once a week (important for some checks like contribution check).

It enables the OpenSSF Scorecard Github Action and Badge to help you to ensure the project will continue to follow the open source best practices or even improve any possible practice to avoid security risks and vulnerabilities.